### PR TITLE
修復 /music play

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -120,6 +120,9 @@ class MusicCog(commands.GroupCog, name='music'):
                     embed.set_image(url=vc.queue[0].thumb)
                     return await i.followup.send(embed=embed)
                 else:
+                    if '&t=' in search:
+                        position = re.search('&t=', search).start()
+                        search = search[:position]
                     try:
                         track = await wavelink.YouTubeTrack.search(query=search, return_first=True)
                     except Exception as e:


### PR DESCRIPTION
當 youtube 連結裡有 '&t=' 時沒辦法播放歌曲
直接把 '&t=' 去掉就行了